### PR TITLE
Update dependency using old upload-artifact/@v3

### DIFF
--- a/.github/actions/setup-mkdocs-material/action.yml
+++ b/.github/actions/setup-mkdocs-material/action.yml
@@ -45,7 +45,7 @@ runs:
         path: ${{ inputs.MKDOCS_SITE_DIR }}/.cache/plugins/optimize
         key: ${{ runner.os }}-hardcoded-media-cache
     - name: Install pngquant, a CI only dependency for mkdocs-material image optimization
-      uses: awalsh128/cache-apt-pkgs-action@v1.2.2
+      uses: awalsh128/cache-apt-pkgs-action@v1.4.3
       with:
         packages: pngquant
     - name: Update python pip


### PR DESCRIPTION
See https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/ (even when the date is weird).

The [docs build again](https://github.com/BetonQuest/BetonQuest/actions/runs/12947064653/job/36112869678).