### PR TITLE
version type artifact that use the repository name in the version now…

### DIFF
--- a/.github/actions/version/action.yml
+++ b/.github/actions/version/action.yml
@@ -100,7 +100,7 @@ runs:
       run: |
         if [ ${{ github.repository }} != ${{ inputs.ROOT_REPOSITORY }} ]; then REPO=${{ github.repository }}-; else REPO=""; fi
         echo "VERSION_MAVEN=${REVISION_VERSION}-DEV-UNOFFICIAL" >> $GITHUB_ENV
-        VERSION=${REVISION_VERSION}-DEV-ARTIFACT-${REPO}${{ github.run_number }}
+        VERSION=${REVISION_VERSION}-DEV-ARTIFACT-${REPO//\//-}${{ github.run_number }}
         echo "VERSION=$VERSION" >> $GITHUB_ENV
     - name: Save version to output variable
       id: version


### PR DESCRIPTION
… replace the slash with a dash to be semantic versioning compatible